### PR TITLE
chore(infra): use ecr when building docker + upgrade to node 22

### DIFF
--- a/.jenkins/Jenkinsfile.cd
+++ b/.jenkins/Jenkinsfile.cd
@@ -23,7 +23,7 @@ pipeline {
                       ]]
                   ])
                   docker.withRegistry("https://${ECR_REGISTRY}", "ecr:${REGION}:${ECR_SECRET_ID}") {
-                      docker.build(IMAGE_NAME)
+                      docker.build(IMAGE_NAME, "--build-arg docker_images_registry=${ECR_REGISTRY}")
                       sh """
                       docker tag ${IMAGE_NAME} ${ECR_REGISTRY}/${IMAGE_NAME}
                       docker push ${ECR_REGISTRY}/${IMAGE_NAME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # v0.7.8
 
+ARG docker_images_registry=docker.io
+
 # Base node image
-FROM node:20-alpine AS node
+FROM ${docker_images_registry}node:20-alpine AS node
 
 # Install jemalloc
 RUN apk add --no-cache jemalloc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # v0.7.8
 
+ARG node_version=22.13.0
 ARG docker_images_registry=docker.io
 
 # Base node image
-FROM ${docker_images_registry}node:20-alpine AS node
+FROM ${docker_images_registry}node:${node_version}-alpine AS node
 
 # Install jemalloc
 RUN apk add --no-cache jemalloc


### PR DESCRIPTION
bai currently uses a base image from docker hub, which counts towards a rate limit.

Lets use ECR instead

https://blnce.atlassian.net/browse/BR-18670